### PR TITLE
Add labels to toolbar buttons

### DIFF
--- a/MeshBuddy/MeshGradientEditor.swift
+++ b/MeshBuddy/MeshGradientEditor.swift
@@ -65,7 +65,7 @@ struct MeshGradientEditor: View {
         } label: {
             Label("Export", systemImage: "photo.badge.arrow.down")
         }
-        .help("Export…")
+        .help("Export as image…")
         .keyboardShortcut("e", modifiers: .command)
     }
 }

--- a/MeshBuddy/MeshGradientEditor.swift
+++ b/MeshBuddy/MeshGradientEditor.swift
@@ -36,7 +36,7 @@ struct MeshGradientEditor: View {
                 gradient.distortPoints(frequency: 4, amplitude: 0.3)
             }
         } label: {
-            Image(systemName: "wand.and.sparkles.inverse")
+            Label("Perlin Noise", systemImage: "wand.and.sparkles.inverse")
         }
         .help("Apply perlin noise")
 
@@ -45,7 +45,7 @@ struct MeshGradientEditor: View {
                 gradient.randomizeMesh()
             }
         } label: {
-            Image(systemName: "dice")
+            Label("Randomize", systemImage: "dice")
         }
         .help("Randomize mesh")
 
@@ -54,7 +54,7 @@ struct MeshGradientEditor: View {
                 gradient.resetPointPositions()
             }
         } label: {
-            Image(systemName: "eraser")
+            Label("Reset", systemImage: "eraser")
         }
         .help("Reset points")
 
@@ -63,7 +63,7 @@ struct MeshGradientEditor: View {
                 await exporter.runExportPanel(for: gradient)
             }
         } label: {
-            Image(systemName: "photo.badge.arrow.down")
+            Label("Export", systemImage: "photo.badge.arrow.down")
         }
         .help("Export…")
         .keyboardShortcut("e", modifiers: .command)


### PR DESCRIPTION
I’ve noticed that switching the toolbar to "icon and text" doesn’t show labels on the buttons.

This small PR adds those labels. Also the export tooltip is slightly tweaked to not repeat the button label and be a little more descriptive.


![CleanShot 2024-09-19 at 23 26 13](https://github.com/user-attachments/assets/6665e18c-ce17-465b-abe6-362204cebb8c)